### PR TITLE
Here's the corrected version of your message:

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,13 +366,13 @@
             <a href="#" class="logo">24 Game Solver</a>
             <ul class="nav-links">
               <li>
-                <a href="https://witchakornb.github.io/witchakornb/" target="_blank"
+                <a href="https://witchakornb.github.io/" target="_blank"
                   >->Home: WitchakornB</a
                 >
               </li>
               <li>
                 <a
-                  href="https://witchakornb.github.io/smart-price-comparator/"
+                  href="https://witchakornb.github.io/Smart-Price-Comparator/"
                   target="_blank"
                   >Smart Price Comparator</a
                 >


### PR DESCRIPTION
Fix: Corrected navigation bar link URLs

I've updated the href attributes for two links in the navigation bar based on your feedback:

- Changed "->Home: WitchakornB" link to point to https://witchakornb.github.io/
- Changed "Smart Price Comparator" link to point to https://witchakornb.github.io/Smart-Price-Comparator/